### PR TITLE
Prepare release 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.4.6] - 2026-01-22
+
+- Add Ruby 3.4 support #3
+- Update magnus from 0.6 to 0.7 for Ruby 3.4 compatibility
+- Update rb-sys from 0.9.82 to 0.9.103
+
 ## [0.4.5] 2024-01-02
 
 - Bump tzf-rs to 0.4.5 #8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tzf (0.4.5)
+    tzf (0.4.6)
       rb_sys (~> 0.9)
 
 GEM

--- a/lib/tzf/version.rb
+++ b/lib/tzf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TZF
-  VERSION = "0.4.5"
+  VERSION = "0.4.6"
 end


### PR DESCRIPTION
## Summary

- Bump version to 0.4.6
- Update CHANGELOG with Ruby 3.4 support changes from #3

## Test plan

- [x] Version updated in `lib/tzf/version.rb`
- [x] CHANGELOG updated with 0.4.6 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)