### PR TITLE
ci(APE-1241): Adds Dependabot configuration linter

### DIFF
--- a/.github/workflows/dependabot-linter.yml
+++ b/.github/workflows/dependabot-linter.yml
@@ -1,0 +1,22 @@
+name: "Lint / Dependabot"
+
+permissions:
+  contents: read # Required to clone the repository
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/dependabot-linter.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint
+        uses: airtasker/dependabot-config-linter@v1


### PR DESCRIPTION
## Why

Dependabot configuration is a pain in that you don't know you've broken it until you merge it.

## What

This adds a composite action that validates Dependabot configuration upon changing it, preventing configuration issues from being merged.
