### PR TITLE
chore(APE-2194): bump BUNDLED WITH to bundler 2.7.2 (latest v2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,4 +77,4 @@ DEPENDENCIES
   tzf!
 
 BUNDLED WITH
-   2.5.4
+   2.7.2


### PR DESCRIPTION
## What

Bump `BUNDLED WITH` to bundler **2.7.2** (latest 2.x) in this repo's Ruby bundle(s). Lockfile-metadata-only; re-resolved with `bundle update --bundler=2.7.2`, no gem versions changed; multi-platform PLATFORMS preserved.

## Why

Bundler <= 2.6.6 overflows the compact_index cache-dir name (NAME_MAX) under GitHub Packages auth -> Errno::ENAMETOOLONG. airtasker/setup-ruby#11 works around it; Bundler 2.6.7 fixes it upstream. Once all repos bundle >= 2.6.7 the workaround can be removed. Latest 2.x, not 4.x.

Tracked by APE-2194.

## Verification

- [ ] CI green
- [x] diff is BUNDLED WITH-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)